### PR TITLE
Fix SQL error in collections table by replacing temporal_extent with separate start/end columns

### DIFF
--- a/database/init.sql
+++ b/database/init.sql
@@ -25,10 +25,10 @@ CREATE TABLE IF NOT EXISTS stac.collections (
     id serial PRIMARY KEY,
     title text,
     description text,
-    source_id integer REFERENCES stac.sources(id) ON DELETE SET NULL, --id that refers to the source of the collection
-    spatial_extent geometry(Polygon, 4326), 
-    temporal_extent timestamptz[temporal_start, temporal_end], --date of the oldest and newest data
     keywords text[], --keywords that describe the data
+    spatial_extent geometry(Polygon, 4326), 
+    temporal_start timestamptz,
+    temporal_end timestamptz,
     providers text[],
     license text,
     doi text[], --Digital Object Identifier of the collection
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS stac.collections (
     constellation_summary text[], --for satellite data: summary of constellations of the satellites (if there are any)
     gsd_summary text[], --for satellite data: summary of the ground sampling distance of the data
     processing_level_summary text[], --for sattelite data: summary of the processing level of the data
+    source_id integer REFERENCES stac.sources(id) ON DELETE SET NULL, --id that refers to the source of the collection
     last_crawled_timestamp timestamptz DEFAULT now() --when was the last time this collection got crawled (successfully)?
 );
 


### PR DESCRIPTION
This PR resolves a SQL syntax error during Docker container initialization caused by the invalid declaration of `temporal_extent` as a labeled array (`timestamptz[temporal_start, temporal_end]`), which is not supported in PostgreSQL.

### Changes:
- Removed `temporal_extent` array declaration
- Added two separate columns: `temporal_start` and `temporal_end` of type `timestamptz`
- Preserved all other fields and references in the `stac.collections` table