### PR TITLE
Add temporary mock data until database is ready

### DIFF
--- a/api/controllers/collections.js
+++ b/api/controllers/collections.js
@@ -1,4 +1,10 @@
-const db = require('../db');
+// TEMPORARY: Set to false when database is ready, then delete these 4 lines
+const USE_MOCK = true;
+const mockDb = require('../db/mockData');
+const realDb = require('../db');
+const db = USE_MOCK ? mockDb : realDb; 
+// After deletion add: const db = require('../db');
+
 const { parseSortby } = require('../utils/sorting');
 const { parsePaginationParams, createPaginationLinks } = require('../utils/pagination');
 

--- a/api/db/mockData.js
+++ b/api/db/mockData.js
@@ -1,0 +1,91 @@
+// TEMPORARY: Delete this entire file when database is ready
+// This file provides mock data for development
+
+const mockCollections = [
+  {
+    id: 1,
+    title: 'Sentinel-2 Level-2A',
+    description: 'Sentinel-2 Level-2A Bottom-of-Atmosphere reflectance data',
+    spatial_extent: {
+      type: 'Polygon',
+      coordinates: [[[5.8663153, 47.2701114], [15.0419319, 47.2701114], [15.0419319, 55.099161], [5.8663153, 55.099161], [5.8663153, 47.2701114]]]
+    },
+    xmin: 5.8663153,
+    ymin: 47.2701114,
+    xmax: 15.0419319,
+    ymax: 55.099161,
+    temporal_start: '2015-06-23T00:00:00Z',
+    temporal_end: '2024-12-31T23:59:59Z',
+    license: 'CC-BY-4.0',
+    keywords: ['sentinel', 'satellite', 'optical'],
+    providers: ['ESA', 'Copernicus'],
+    doi: '10.5067/SENTINEL2/MSI',
+    platform_summary: ['Sentinel-2A', 'Sentinel-2B'],
+    constellation_summary: ['Sentinel-2'],
+    gsd_summary: ['10m', '20m', '60m'],
+    processing_level_summary: ['L2A']
+  },
+  {
+    id: 2,
+    title: 'Landsat 8 Collection 2',
+    description: 'Landsat 8 operational land imager and thermal infrared sensor',
+    spatial_extent: {
+      type: 'Polygon',
+      coordinates: [[[5.8663153, 47.2701114], [15.0419319, 47.2701114], [15.0419319, 55.099161], [5.8663153, 55.099161], [5.8663153, 47.2701114]]]
+    },
+    xmin: 5.8663153,
+    ymin: 47.2701114,
+    xmax: 15.0419319,
+    ymax: 55.099161,
+    temporal_start: '2013-04-01T00:00:00Z',
+    temporal_end: '2024-12-31T23:59:59Z',
+    license: 'CC0-1.0',
+    keywords: ['landsat', 'satellite', 'multispectral'],
+    providers: ['USGS', 'NASA'],
+    doi: '10.5066/LANDSAT8',
+    platform_summary: ['Landsat-8'],
+    constellation_summary: ['Landsat'],
+    gsd_summary: ['30m'],
+    processing_level_summary: ['L1TP', 'L2SP']
+  },
+  {
+    id: 3,
+    title: 'MODIS Terra Daily',
+    description: 'MODIS Terra daily surface reflectance product',
+    spatial_extent: {
+      type: 'Polygon',
+      coordinates: [[[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]]]
+    },
+    xmin: -180,
+    ymin: -90,
+    xmax: 180,
+    ymax: 90,
+    temporal_start: '2000-02-24T00:00:00Z',
+    temporal_end: '2024-12-31T23:59:59Z',
+    license: 'proprietary',
+    keywords: ['modis', 'terra', 'daily'],
+    providers: ['NASA'],
+    doi: '10.5067/MODIS/MOD09GA',
+    platform_summary: ['Terra'],
+    constellation_summary: ['Terra'],
+    gsd_summary: ['1km'],
+    processing_level_summary: ['L2']
+  }
+];
+
+module.exports = {
+  query: async (text, params) => {
+    // Mock getCollections query
+    if (text.includes('SELECT id, title, description, keywords')) {
+      return { rows: mockCollections };
+    }
+    
+    // Mock getCollectionById query
+    if (text.includes('ST_XMin') && params && params.length > 0) {
+      const collection = mockCollections.find(c => c.id == params[0]);
+      return { rows: collection ? [collection] : [] };
+    }
+    
+    return { rows: [] };
+  }
+};


### PR DESCRIPTION
**Added:**
- `api/db/mockData.js` - added 3 examples
- `api/controllers/collections.js` - added 4 lines at the start of the controller to toggle between mock data and real database using USE_MOCK constant

**Usage:**
- Set `USE_MOCK = true/false` in `collections.js`  

**Removal (when database is ready):**
 - Delete `mockData.js` + 4 lines in `collections.js`
