### PR TITLE
Feature/stac migrate

### DIFF
--- a/crawler/crawling/migrator.js
+++ b/crawler/crawling/migrator.js
@@ -1,0 +1,33 @@
+import Migrate from '@radiantearth/stac-migrate';
+
+/**
+ * Normalizes STAC Collection to the newest Version (STAC 1.1).
+ 
+ * * @param {Object} rawData - raw JSON-Object.
+ * @param {string} sourceUrl - Source URL (for Logs).
+ * @returns {Promise<Object>} Object with migrated Collection and Version.
+ */
+export async function normalizeCollection(rawData, sourceUrl) {
+    try {
+       
+        //creating copy (Deep Clone), to avoid side effects.
+        const collectionCopy = JSON.parse(JSON.stringify(rawData));
+
+        // Parameter true = updateVersionNumber (updates 'stac_version' Field)
+        const migratedCollection = Migrate.collection(collectionCopy, true);
+
+        // reading version from the migrated object
+        const version = migratedCollection.stac_version;
+
+        console.log(`[INFO] Migration succesful for ${sourceUrl}. Version: ${version}`);
+
+        return {
+            collection: migratedCollection,
+            stacVersion: version
+        };
+
+    } catch (error) {
+        console.error(`[ERROR] Error  ${sourceUrl}:`, error.message);
+        throw error;
+    }
+}

--- a/crawler/data_management/dbProcessor.js
+++ b/crawler/data_management/dbProcessor.js
@@ -1,0 +1,58 @@
+import { normalizeCollection } from './migrator.js';
+
+/**
+ * Processes the crawled JSON and prepares the database object.
+ * * @param {Object} rawJson - The raw crawled JSON.
+ * @param {string} sourceUrl - The URL of the collection.
+ * @param {number} sourceId - The ID of the source from the 'sources' table.
+ * @returns {Promise<Object|null>} The object ready for DB insertion, or null on error.
+ */
+export async function prepareForDatabase(rawJson, sourceUrl, sourceId) {
+    
+    // Step 1: Migration / Normalization
+    let cleanData;
+    try {
+        cleanData = await normalizeCollection(rawJson, sourceUrl);
+    } catch (error) {
+    
+        return null; 
+    }
+
+    const { collection, stacVersion } = cleanData;
+
+    // Helper function to safely access deeply nested properties
+    const getDeep = (obj, path) => path.split('.').reduce((acc, part) => acc && acc[part], obj);
+
+    // Step 2: Mapping to the Database Schema
+    const dbEntry = {
+        // Primary Key and Identification
+        id: collection.id,
+        
+        // IMPORTANT: Storing the STAC version
+        stac_version: stacVersion,
+        
+        // IMPORTANT: Storing the full migrated JSON content
+        full_content: collection, 
+        
+        // Source Information 
+        fk_source_id: sourceId,
+        source_url: sourceUrl,
+        last_crawled_timestamp: new Date().toISOString(),
+
+        // Metadata Extraction
+        title: collection.title || null,
+        description: collection.description || null,
+        keywords: collection.keywords || [],
+        license: collection.license || null,
+        
+        // Geometries for PostGIS (spatial) and Intervals (temporal)
+        spatial_extent: getDeep(collection, 'extent.spatial.bbox'),
+        temporal_extent: getDeep(collection, 'extent.temporal.interval'),
+
+        // Additional Summaries (Providers, Platforms, etc.)
+        platforms: getDeep(collection, 'summaries.platform') || [],
+        constellations: getDeep(collection, 'summaries.constellation') || []
+    };
+
+    return dbEntry;
+}


### PR DESCRIPTION
 Implements the necessary changes to comply with the latest STAC Specification (v1.1.0).

- Implemented a migration layer to automatically convert and handle older (legacy) STAC data upon retrieval.
- Updated all STAC object fields and metadata structures to match the new v1.1.0 schema.

