### PR TITLE
feat: implement parent reference for stac collections

### DIFF
--- a/crawler/crawling/crawler_engine.js
+++ b/crawler/crawling/crawler_engine.js
@@ -36,6 +36,7 @@ export async function startCrawler() {
         // Fetch next URL entry from queue table
         const entry = await getNextUrlFromDB();
         const url = entry.url_of_source;
+        const parentUrl = entry.parent_url ?? null;
 
         //get the json from the url
         const res = await fetch(url)
@@ -48,7 +49,7 @@ export async function startCrawler() {
 
             //for Catalogs: put the child urls into the queue
             //for Collections: put the child urls into the queue, save the data in the sources/collections db
-            handleSTACObject(STACObject, url)
+            await handleSTACObject(STACObject, url, parentUrl)
     
             } else {
                 logger.warn("Warning: Invalid STAC object")

--- a/crawler/crawling/crawler_functions.js
+++ b/crawler/crawling/crawler_functions.js
@@ -1,5 +1,5 @@
 //imports
-import { upsertCollection, upsertSource } from "../data_management/db_writer.js"
+import { getSourceIdByUrl, upsertCollection, upsertSource } from "../data_management/db_writer.js"
 import { validateStacObject } from "../parsing/json_validator.js"
 import { addToQueue } from "./queue_manager.js"
 import { logger } from "./src/config/logger.js"
@@ -12,57 +12,91 @@ import { logger } from "./src/config/logger.js"
  * @function handleSTACObject
  * saves child urls and collection data based on the type of the given stac object
  * @param {JSON} STACObject - given stac object, any type
- * @param {*} Link - link to the stac object
+ * @param {string} Link - link to the stac object
+ * @param {string|null} parentUrl - url of the parent catalog/collection as stored in the queue
  * @returns 
  */
-export async function handleSTACObject(STACObject, Link) {
+export function makeHandleSTACObject(deps = {}) {
+    const {
+        validateStacObject: validate = validateStacObject,
+        upsertSource: upsertSourceFn = upsertSource,
+        getSourceIdByUrl: getSourceIdByUrlFn = getSourceIdByUrl,
+        upsertCollection: upsertCollectionFn = upsertCollection,
+        addToQueue: addToQueueFn = addToQueue,
+        getChildURLs: getChildURLsFn = getChildURLs,
+        logger: loggerFn = logger,
+    } = deps
 
-    //only run the following code if the stac object is valid
-    if (validateStacObject(STACObject).valid) {
-        
-        //check the type of the stac object
-        let STACObjectType = STACObject.type
+    return async function handleSTACObjectImpl(STACObject, Link, parentUrl = null) {
 
-        //depending on the type, run the following code:
-        if (STACObjectType == "Catalog") {
-
-            //get the titles and urls of the childs
-            let childs = getChildURLs(STACObject, Link)
-
-            //put the URLs into the queue
-            for (let child of childs) {
-                await addToQueue(child.title, child.url)
-            }
-
-        } else if (STACObjectType == "Collection") {
+        //only run the following code if the stac object is valid
+        if (validate(STACObject).valid) {
             
-            //get the title and the urls of the childs
-            let childs = getChildURLs(STACObject, Link)
+            //check the type of the stac object
+            let STACObjectType = STACObject.type
 
-            //put the URLs into the queue
-            for (let child of childs) {
-                await addToQueue(child.title, child.url)
+            // Track the source id of the currently crawled Catalog/Collection (self)
+            let currentSourceId = null
+
+            // Catalogs and Collections should be stored in sources
+            if (STACObjectType === "Catalog" || STACObjectType === "Collection") {
+                const sourceData = {
+                    url: Link,
+                    title: STACObject.title,
+                    type: STACObject.type
+                }
+                currentSourceId = await upsertSourceFn(sourceData)
             }
 
-            //save source data
-            let sourceData = {
-                url: Link,
-                title: STACObject.title,
-                type: STACObject.type
+            //depending on the type, run the following code:
+            if (STACObjectType == "Catalog") {
+
+                //get the titles and urls of the childs
+                let childs = getChildURLsFn(STACObject, Link)
+
+                //put the URLs into the queue
+                for (let child of childs) {
+                    await addToQueueFn(child.title, child.url, Link)
+                }
+
+            } else if (STACObjectType == "Collection") {
+                
+                //get the title and the urls of the childs
+                let childs = getChildURLsFn(STACObject, Link)
+
+                //put the URLs into the queue
+                for (let child of childs) {
+                    await addToQueueFn(child.title, child.url, Link)
+                }
+
+                // Resolve parent source_id from sources table via parentUrl
+                let parentSourceId = null
+                if (parentUrl) {
+                    parentSourceId = await getSourceIdByUrlFn(parentUrl)
+                    if (!parentSourceId) {
+                        loggerFn.warn(`Could not resolve parent source id for collection ${Link} (parentUrl=${parentUrl})`)
+                    }
+                } else {
+                    // Root-collection (start URL) should link to itself as source
+                    parentSourceId = currentSourceId
+                }
+
+                // save collection data with FK to its parent source (if available)
+                await upsertCollectionFn({ ...STACObject, source_id: parentSourceId })
+
+            } else {
+                return
             }
-
-            //insert source data into source table
-            await upsertSource(sourceData)
-
-            //save collection data
-            await upsertCollection(STACObject)
-
         } else {
-            return
+            loggerFn.warn("Warning: Invalid STAC object")
         }
-    } else {
-        logger.warn("Warning: Invalid STAC object")
     }
+}
+
+const _defaultHandleSTACObject = makeHandleSTACObject()
+
+export async function handleSTACObject(STACObject, Link, parentUrl = null) {
+    return _defaultHandleSTACObject(STACObject, Link, parentUrl)
 }
 
 /**

--- a/crawler/data_management/db_writer.js
+++ b/crawler/data_management/db_writer.js
@@ -36,6 +36,19 @@ export async function upsertSource(source) {
 }
 
 /**
+ * Resolve a source id by its URL.
+ * @param {string} url
+ * @returns {Promise<number|null>} id if found, otherwise null
+ */
+export async function getSourceIdByUrl(url) {
+  const res = await pool.query(
+    `SELECT id FROM stac.sources WHERE url = $1 LIMIT 1;`,
+    [url]
+  );
+  return res.rows[0]?.id ?? null;
+}
+
+/**
  * Insert or update a STAC collection with metadata normalization
  * Handles array/JSON conversions, spatial geometry, and temporal bounds 
  * Implements Duplicate Handling via Upsert Strategy


### PR DESCRIPTION
- Added 'parent_url' column to urlQueue table to track parent-child lineage
- Added SERIAL 'id' column for proper FIFO ordering 
- Updated queue_manager to persist parent context
- Enhanced crawler_functions to resolve source_id from parent_url
- Added function to db_writer to allow resolving source IDs by its URL