### PR TITLE
adding test for collection/{id} in collection integration test

### DIFF
--- a/api/tests/integration/collections.test.js
+++ b/api/tests/integration/collections.test.js
@@ -42,3 +42,38 @@ describe('GET /collections', () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe('GET /collections/:id', () => {
+  test('should return a single collection by id', async () => {
+    // Erst eine Collection aus der Liste holen
+    const listRes = await request(app).get('/collections?limit=1');
+    const collectionId = listRes.body.collections[0]?.id;
+    
+    expect(collectionId).toBeDefined();
+    
+    const res = await request(app).get(`/collections/${collectionId}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('id', collectionId);
+    expect(res.body).toHaveProperty('type', 'Collection');
+    expect(res.body).toHaveProperty('stac_version', '1.0.0');
+  });
+
+  test('should return 404 for non-existent collection', async () => {
+    const res = await request(app).get('/collections/non-existent-id-12345');
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error', 'Collection not found');
+  });
+
+  test('should include required STAC links', async () => {
+    const listRes = await request(app).get('/collections?limit=1');
+    const collectionId = listRes.body.collections[0]?.id;
+    
+    const res = await request(app).get(`/collections/${collectionId}`);
+    expect(res.status).toBe(200);
+    
+    const links = res.body.links;
+    expect(links.find(l => l.rel === 'self')).toBeDefined();
+    expect(links.find(l => l.rel === 'root')).toBeDefined();
+    expect(links.find(l => l.rel === 'parent')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Integration Tests für Collections API

### Beschreibung

Dieser Branch fügt Integration Tests für die Collections API hinzu, um sicherzustellen, dass die Endpoints korrekt funktionieren und die STAC-Spezifikation einhalten.

### Neue Tests

#### `GET /collections/:id`
| Test | Beschreibung |
|------|--------------|
| Single Collection | Prüft ob eine Collection per ID abgerufen werden kann |
| 404 Not Found | Prüft ob nicht existierende IDs einen 404-Fehler zurückgeben |
| STAC Links | Prüft ob die erforderlichen Links (`self`, `root`, `parent`) vorhanden sind |

### Technische Details

- **Framework**: Jest + Supertest
- **Testart**: Integration Tests (echte HTTP-Requests gegen die API)
- **Datei**: `api/tests/integration/collections.test.js`

### Ausführung

```bash
npx jest tests/integration/collections.test.js --forceExit