### PR TITLE
feat: implement retry logic & rate limiting

### DIFF
--- a/crawler/crawling/crawler_engine.js
+++ b/crawler/crawling/crawler_engine.js
@@ -1,4 +1,3 @@
-
 //imports 
 import {
     initializeQueue,
@@ -11,6 +10,40 @@ import { handleSTACObject } from "./crawler_functions.js"
 import { validateStacObject } from "../parsing/json_validator.js";
 import { logger } from "./src/config/logger.js"
 import { getSTACIndexData } from "../data_management/stac_index_client.js";
+
+const CRAWL_DELAY_MS = 1000; // Polite delay
+const MAX_RETRIES = 3;       // Max attempts
+const RETRY_DELAY_MS = 2000; // Base backoff time
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Retry-aware fetch:
+ * - retries: Network errors, 5xx Server Errors, and 429 (Rate Limit) with linear backoff.
+ * - aborts fast on fatal 4xx (except 429)
+ * - returns parsed JSON on success
+ */
+async function fetchWithRetry(url, maxRetries = MAX_RETRIES) {
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+            logger.info(`Fetching ${url} (attempt ${attempt}/${maxRetries})`);
+            const response = await fetch(url);
+            const status = response.status;
+            if (response.ok) return await response.json();
+            if (status >= 400 && status < 500 && status !== 429) {
+                throw new Error(`Fatal Client Error ${status}: ${response.statusText} - Will not retry.`);
+            }
+            throw new Error(`Request failed with status ${status}: ${response.statusText}`);
+        } catch (error) {
+            if (error.message.includes("Fatal Client Error")) throw error;
+            logger.warn(`Attempt ${attempt} failed for ${url}: ${error.message}`);
+            if (attempt === maxRetries) throw new Error(`Failed after ${maxRetries} attempts: ${error.message}`);
+            const delay = RETRY_DELAY_MS * attempt;
+            logger.info(`Waiting ${delay}ms before next retry...`);
+            await sleep(delay);
+        }
+    }
+}
 
 /**
 * Main crawler loop:
@@ -32,12 +65,14 @@ export async function startCrawler() {
     // Initialize queue from database
     await initializeQueue();
 
-    // get the urls from the STAC Index db
-    const STACIndexData = await getSTACIndexData();
-    
-    //push the urls to the queue
-    for (let data of STACIndexData) {
-        await addToQueue(data.title, data.url);
+    // Load URLs from STAC Index (fail-safe)
+    try {
+        const STACIndexData = await getSTACIndexData();
+        for (let data of STACIndexData) {
+            await addToQueue(data.title, data.url);
+        }
+    } catch (err) {
+        logger.error("Could not load STAC Index data, starting with existing queue only.");
     }
 
     // Continue crawling until no URLs remain in queue
@@ -45,28 +80,35 @@ export async function startCrawler() {
         
         // Fetch next URL entry from queue table
         const entry = await getNextUrlFromDB();
+        
+        // Safety check against race conditions
+        if (!entry) {
+            await sleep(1000);
+            continue;
+        }
         const url = entry.url_of_source;
         const parentUrl = entry.parent_url ?? null;
 
-        //get the json from the url
-        const res = await fetch(url)
-        const STACObject = await res.json()
+        try {
+            console.log(`Crawling: ${url}`);
+            const STACObject = await fetchWithRetry(url);
+            
+            // Only proceed if valid JSON was retrieved
+            if (validateStacObject(STACObject).valid) {
 
-        console.log(`Crawling: ${url}`);
-        
-        // Only proceed if valid JSON was retrieved
-        if (validateStacObject(STACObject).valid) {
-
-            //for Catalogs: put the child urls into the queue
-            //for Collections: put the child urls into the queue, save the data in the sources/collections db
-            await handleSTACObject(STACObject, url, parentUrl)
-    
+                //for Catalogs: put the child urls into the queue
+                //for Collections: put the child urls into the queue, save the data in the sources/collections db
+                await handleSTACObject(STACObject, url, parentUrl)
             } else {
-                logger.warn("Warning: Invalid STAC object")
+                logger.warn(`Invalid STAC object at ${url}`)
             }
+        } catch (error) {
+            logger.error(`Skipping ${url} -> ${error.message}`);
+        }
         
-            // Remove processed URL from queue to avoid re-processing
+        // Remove processed URL from queue to avoid re-processing
         await removeFromQueue(url);
+        await sleep(CRAWL_DELAY_MS);
     }
 
     console.log("Crawling finished");


### PR DESCRIPTION
**Retry Logic (#57):**
- Implemented `fetchWithRetry()` with linear backoff (2s → 4s → 6s)
- Retries network errors, 5xx, and 429 (rate limit)
- Aborts immediately on fatal 4xx errors (except 429)

**Rate Limiting (#122):**
- Added `sleep()` helper and `CRAWL_DELAY_MS` (1s) between requests
- Prevents IP bans and respects server load

**Configuration:**
- `CRAWL_DELAY_MS = 1000` 
- `MAX_RETRIES = 3` 
- `RETRY_DELAY_MS = 2000` 