### PR TITLE
adding documentation for health and queryables endpoint

### DIFF
--- a/docs/api/health.md
+++ b/docs/api/health.md
@@ -1,0 +1,169 @@
+# Health Endpoint
+
+## Overview
+
+The Health endpoint provides a simple health check for the API and database connectivity. It can be used for monitoring, load balancing, and ensuring system availability.
+
+**Available Endpoint:**
+- `GET /health` - Check API and database status
+
+---
+
+## GET /health
+
+Returns the current health status of the API and its database connection.
+
+### Request
+```
+GET /health
+```
+
+### Query Parameters
+
+This endpoint does not accept any query parameters.
+
+### Response
+
+Returns a JSON object indicating the health status of the API components.
+
+**Response Structure (Success):**
+```json
+{
+  "status": "ok",
+  "api": "up",
+  "database": "up",
+  "target": {
+    "host": "finder.stacindex.org",
+    "port": "5432",
+    "database": "stacfinder"
+  },
+  "timestamp": "2026-01-19T12:21:52.700Z"
+}
+```
+
+**Response Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | Overall system status: "ok" or "degraded" |
+| `api` | string | API service status: "up" or "down" |
+| `database` | string | Database connection status: "up" or "down" |
+| `target` | object | Database connection information |
+| `target.host` | string | Database host address |
+| `target.port` | string | Database port number |
+| `target.database` | string | Database name |
+| `timestamp` | string | ISO8601 timestamp of the health check |
+
+### Example Check system health
+
+```bash
+curl "http://localhost:4000/health"
+```
+Returns the current health status.
+
+### Success Response
+
+#### 200 OK
+Returned when both API and database are operational.
+```json
+{
+  "status": "ok",
+  "api": "up",
+  "database": "up",
+  "target": {
+    "host": "finder.stacindex.org",
+    "port": "5432",
+    "database": "stacfinder"
+  },
+  "timestamp": "2026-01-19T12:21:52.700Z"
+}
+```
+
+### Error Responses
+
+#### 503 Service Unavailable
+Returned when the database connection fails but the API is still responding.
+```json
+{
+  "status": "degraded",
+  "api": "up",
+  "database": "down",
+  "target": {
+    "host": "finder.stacindex.org",
+    "port": "5432",
+    "database": "stacfinder"
+  },
+  "timestamp": "2026-01-19T12:21:52.700Z"
+}
+```
+
+**Possible Causes:**
+- Database server is down
+- Network connectivity issues
+- Invalid database credentials
+- Database is overloaded or unresponsive
+
+---
+
+## Health Check Behavior
+
+The health check performs the following operations:
+
+1. **API Check**: Always returns "up" if the endpoint responds
+2. **Database Check**: Executes a simple `SELECT 1` query to verify connectivity
+3. **Response Time**: Typically responds in milliseconds for a healthy system
+4. **No Side Effects**: The health check does not modify any data
+
+### Status Interpretation
+
+| Status | API | Database | Meaning |
+|--------|-----|----------|---------|
+| `ok` | up | up | System is fully operational |
+| `degraded` | up | down | API is running but database is unavailable |
+
+---
+
+## Use Cases
+
+### Monitoring and Alerting
+```bash
+# Check if system is healthy
+if [ $(curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/health) -eq 200 ]; then
+  echo "✓ System healthy"
+else
+  echo "✗ System degraded - alert admin"
+fi
+```
+
+### Load Balancer Configuration
+Configure your load balancer to use `/health` as the health check endpoint:
+- **Health check path**: `/health`
+- **Expected status code**: `200`
+- **Check interval**: 5-30 seconds
+- **Timeout**: 2-5 seconds
+- **Unhealthy threshold**: 2-3 consecutive failures
+
+### Container Orchestration
+For Docker/Kubernetes health probes:
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 4000
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 4000
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+---
+
+## Related Documentation
+
+- [Collections](collections.md) - Main collections endpoints
+- [Queryables](queryables.md) - Queryables schema endpoint

--- a/docs/api/queryables.md
+++ b/docs/api/queryables.md
@@ -1,0 +1,194 @@
+# Queryables Endpoint
+
+## Overview
+
+The Queryables endpoint provides a JSON Schema description of all fields that can be used for filtering STAC Collections. This follows the STAC API Filter Extension and helps clients discover which properties are available for querying.
+
+**Available Endpoint:**
+- `GET /queryables` - Retrieve schema of filterable fields
+
+---
+
+## GET /queryables
+
+Returns a Queryables object describing all fields available for filtering collections.
+
+### Request
+```
+GET /queryables
+```
+
+### Query Parameters
+
+This endpoint does not accept any query parameters.
+
+### Response
+
+Returns a JSON object conforming to the Queryables specification.
+
+**Response Structure:**
+```json
+{
+  "type": "Queryables",
+  "title": "Filterbare Felder für STAC-Collections",
+  "description": "Diese Ressource beschreibt alle Felder, nach denen in /collections gefiltert werden kann.",
+  "properties": {
+    "title": {
+      "type": "string",
+      "title": "Titel",
+      "description": "Titel der Collection für Freitextsuche"
+    },
+    "description": {
+      "type": "string",
+      "title": "Beschreibung",
+      "description": "Beschreibung der Collection für Freitextsuche"
+    },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string" },
+      "title": "Schlagworte",
+      "description": "Keywords zur thematischen Filterung"
+    },
+    "license": {
+      "type": "string",
+      "title": "Lizenz",
+      "description": "Lizenz der Daten (z.B. CC-BY-4.0, proprietary)"
+    },
+    "platform_summary": {
+      "type": "array",
+      "items": { "type": "string" },
+      "title": "Plattformen",
+      "description": "Satelliten/Plattformen (z.B. Sentinel-2, Landsat-8)"
+    },
+    "constellation_summary": {
+      "type": "array",
+      "items": { "type": "string" },
+      "title": "Konstellationen",
+      "description": "Satelliten-Konstellationen (z.B. Sentinel, Landsat)"
+    },
+    "gsd_summary": {
+      "type": "array",
+      "items": { "type": "string" },
+      "title": "Ground Sampling Distance",
+      "description": "Bodenauflösung der Daten (z.B. 10m, 30m)"
+    },
+    "processing_level_summary": {
+      "type": "array",
+      "items": { "type": "string" },
+      "title": "Verarbeitungslevel",
+      "description": "Verarbeitungsstufe der Daten (z.B. L1C, L2A)"
+    },
+    "spatial_extent": {
+      "type": "object",
+      "title": "Räumliche Ausdehnung",
+      "description": "Geografische Bounding Box für räumliche Filterung (GeoJSON Polygon)",
+      "properties": {
+        "type": { "type": "string" },
+        "coordinates": { "type": "array" }
+      }
+    },
+    "temporal_extent": {
+      "type": "array",
+      "items": { "type": "string", "format": "date-time" },
+      "minItems": 2,
+      "maxItems": 2,
+      "title": "Zeitliche Ausdehnung",
+      "description": "Zeitraum der Daten [Start, Ende] für zeitliche Filterung"
+    }
+  }
+}
+```
+
+**Response Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Always "Queryables" |
+| `title` | string | Human-readable title of the queryables schema |
+| `description` | string | Description of the queryables resource |
+| `properties` | object | Object containing all filterable field definitions |
+
+**Available Queryable Properties:**
+
+| Property | Type | Description | Example Usage |
+|----------|------|-------------|---------------|
+| `title` | string | Collection title for free-text search | Used with `q` parameter |
+| `description` | string | Collection description for free-text search | Used with `q` parameter |
+| `keywords` | array[string] | Keywords for thematic filtering | Filter: `keywords LIKE '%sentinel%'` |
+| `license` | string | Data license identifier | Filter: `license = 'CC-BY-4.0'` |
+| `platform_summary` | array[string] | Satellite/platform names | Filter: `'Sentinel-2A' IN platform_summary` |
+| `constellation_summary` | array[string] | Satellite constellations | Filter: `'Sentinel' IN constellation_summary` |
+| `gsd_summary` | array[string] | Ground sampling distance values | Filter: `'10m' IN gsd_summary` |
+| `processing_level_summary` | array[string] | Data processing levels | Filter: `'L2A' IN processing_level_summary` |
+| `spatial_extent` | object | Geographic bounding box (GeoJSON Polygon) | Used with `bbox` parameter |
+| `temporal_extent` | array[date-time] | Time range [start, end] | Used with `datetime` parameter |
+
+### Example Retrieve queryables schema
+
+```bash
+curl "http://localhost:4000/collections/queryables"
+```
+Returns the complete queryables schema.
+
+### Error Responses
+
+#### 500 Internal Server Error
+Returned when a server error occurs.
+```json
+{
+  "error": "Internal server error"
+}
+```
+
+---
+
+## Usage with Filter Parameters
+
+The queryables schema describes which fields can be used with the following query parameters on `/collections`:
+
+### Free-text Search (`q`)
+Searches across these fields:
+- `title`
+- `description`
+
+### CQL2 Filtering (`filter`)
+All properties listed in the queryables response can be used in CQL2 filter expressions:
+
+**String filters:**
+```
+filter=license='CC-BY-4.0'
+filter=title LIKE '%Sentinel%'
+```
+
+**Array filters:**
+```
+filter='Sentinel-2A' IN platform_summary
+filter='L2A' IN processing_level_summary
+```
+
+**Spatial filters:**
+Via `bbox` parameter (corresponds to `spatial_extent` queryable)
+
+**Temporal filters:**
+Via `datetime` parameter (corresponds to `temporal_extent` queryable)
+
+---
+
+## STAC Conformance
+
+This endpoint follows the STAC API Filter Extension specification:
+
+- Returns a Queryables object with `type: "Queryables"`
+- Provides JSON Schema definitions for all filterable properties
+- Includes property types, titles, and descriptions
+- Describes both simple properties (strings) and complex properties (arrays, objects)
+- Supports discovery of available filter fields before querying
+
+## Related Documentation
+
+- [Collections](collections.md) - Collections endpoints that use these queryables
+- [Free-text search](filtering/free-text-search.md) - Free-text search using title/description
+- [CQL2-text Filtering](filtering/cql2-text.md) - Using queryables in CQL2 filters
+- [CQL2-json Filtering](filtering/cql2-json.md) - Using queryables in JSON filters
+- [Datetime Filtering](filtering/datetime.md) - Temporal filtering details
+- [Bounding Box Filtering](filtering/bbox.md) - Spatial filtering details


### PR DESCRIPTION
This pull request adds comprehensive API documentation for two endpoints: `/health` and `/queryables`. The documentation provides detailed descriptions, response structures, example usages, and integration guidance for each endpoint, making it easier for developers and operators to monitor system health and understand available query filters for collections.

**New API documentation:**

*Health endpoint documentation*:
- Added `docs/api/health.md` with a full description of the `/health` endpoint, including response formats, status meanings, example usage for monitoring, and integration tips for load balancers and container orchestration.

*Queryables endpoint documentation*:
- Added `docs/api/queryables.md` describing the `/queryables` endpoint, detailing the JSON Schema for filterable fields, example response, supported properties, and guidance on using these fields with collection queries and CQL2 filters.