### PR TITLE
fixing links-href

### DIFF
--- a/api/controllers/collections.js
+++ b/api/controllers/collections.js
@@ -10,9 +10,13 @@ const queryableMap = require('../utils/queryableMap');
 const getCollections = async (req, res) => {
   try {
     let sql =
-      'SELECT id, title, description, keywords, license, temporal_start, temporal_end, providers, ' +
-      'ST_AsGeoJSON(spatial_extent)::json as spatial_extent ' +
-      'FROM test.collections';
+  'SELECT c.id, c.title, c.description, c.keywords, c.license, ' +
+  'c.temporal_start, c.temporal_end, c.providers, ' +
+  's.url AS source_url, ' +
+  'ST_AsGeoJSON(c.spatial_extent)::json as spatial_extent ' +
+  'FROM test.collections c ' +
+  'LEFT JOIN test.sources s ON c.source_id = s.id';
+
 
     const queryParams = [];
     const whereParts = [];
@@ -144,7 +148,14 @@ const getCollections = async (req, res) => {
         license: row.license,
         keywords: row.keywords,
         providers: row.providers?.map((name) => ({ name })),
-        links: [{ rel: 'self', href: `/collections/${row.id}`, type: 'application/json' }]
+        links: [
+          { rel: 'self', href: `/collections/${row.id}`, type: 'application/json' },
+          ...(row.source_url
+            ? [{ rel: 'via', href: row.source_url, type: 'text/html' }]
+            : [])
+        ]
+
+
       };
     });
 
@@ -159,28 +170,32 @@ const getCollections = async (req, res) => {
 };
    
 const getCollectionById = async (req, res) => {
-    const { id } = req.params;
+  const { id } = req.params;
 
-    try {
-        // Extend the query to extract BBox coordinates directly from the geometry
-        const query = `
-            SELECT *, 
-                   ST_XMin(spatial_extent) as xmin, 
-                   ST_YMin(spatial_extent) as ymin, 
-                   ST_XMax(spatial_extent) as xmax, 
-                   ST_YMax(spatial_extent) as ymax 
-            FROM test.collections 
-            WHERE id = $1
-        `;
+  try {
+    const query = `
+      SELECT 
+        c.*,
+        s.url AS source_url,
+        ST_XMin(c.spatial_extent) as xmin, 
+        ST_YMin(c.spatial_extent) as ymin, 
+        ST_XMax(c.spatial_extent) as xmax, 
+        ST_YMax(c.spatial_extent) as ymax 
+      FROM test.collections c
+      LEFT JOIN test.sources s ON c.source_id = s.id
+      WHERE c.id = $1
+    `;
 
-        const result = await db.query(query, [id]);
+    const result = await db.query(query, [id]);
 
-        if (result.rows.length === 0) {
-            return res.status(404).json({
-                error: 'Collection not found',
-                message: `No collection with id "${id}" found`
-            });
-        }
+
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({
+        error: 'Collection not found',
+        message: `No collection with id "${id}" found`
+      });
+    }
 
         const row = result.rows[0]; 
 
@@ -211,23 +226,27 @@ const getCollectionById = async (req, res) => {
                 'processing:level': row.processing_level_summary
             },
 
-            links: [
-                {
-                    rel: 'self',
-                    href: `/collections/${row.id}`,
-                    type: 'application/json'
-                },
-                {
-                    rel: 'root',
-                    href: '/',
-                    type: 'application/json'
-                },
-                {
-                    rel: 'parent',
-                    href: '/collections',
-                    type: 'application/json'
-                }
-            ]
+          links: [
+            {
+              rel: 'self',
+              href: `/collections/${row.id}`,
+              type: 'application/json'
+            },
+            {
+              rel: 'root',
+              href: '/',
+              type: 'application/json'
+            },
+            {
+              rel: 'parent',
+              href: '/collections',
+              type: 'application/json'
+            },
+            ...(row.source_url
+              ? [{ rel: 'via', href: row.source_url, type: 'text/html' }]
+              : [])
+          ]
+
         };
 
         


### PR DESCRIPTION
## Add source URLs to STAC Collection links via database join

### Summary
This pull request enhances the STAC Collections API by correctly linking collections to their external data sources.

Instead of relying on a static or placeholder value, the API now dynamically resolves the source URL by joining the `collections.source_id` column with the `sources` table.

### Changes
- Added a `LEFT JOIN` between `test.collections` and `test.sources` in both:
  - `GET /collections`
  - `GET /collections/{id}`
- Selected `sources.url` as `source_url` in the SQL queries
- Added a `rel: "via"` link to each collection response when a source URL is available
- Preserved the existing `rel: "self"`, `root`, and `parent` links to remain STAC-compliant

### Rationale
According to the STAC specification:
- `rel: "self"` should always reference the API endpoint
- External data providers or landing pages should be referenced via an additional link (e.g. `rel: "via"`)

This change improves semantic correctness and allows clients to discover the original data source of each collection.

### Notes
- A `LEFT JOIN` is used to avoid excluding collections without an associated source
- Currently, all collections reference the same `source_id`; this will be addressed in a follow-up by improving data ingestion

### Impact
- No breaking changes to the API
- No changes to filtering, sorting, or pagination logic
- Improves STAC compliance and metadata completeness
