### PR TITLE
fix: optimize fetch timeouts & refactor retry logic

### DIFF
--- a/crawler/crawling/crawler_engine.js
+++ b/crawler/crawling/crawler_engine.js
@@ -10,7 +10,7 @@ import {
 } from "./queue_manager.js";
 
 import { loadUncrawledSources } from "./source_manager.js";
-import { handleSTACObject, crawlStacApi, validateQueueEntry } from "./crawler_functions.js"
+import { handleSTACObject, crawlStacApi, validateQueueEntry, fetchWithRetry } from "./crawler_functions.js"
 import { validateStacObject } from "../parsing/json_validator.js";
 import { logger } from "./src/config/logger.js"
 import { getSTACIndexData } from "../data_management/stac_index_client.js";
@@ -25,38 +25,8 @@ const __dirname = path.dirname(__filename)
 const backupFilePath = path.resolve(__dirname, "./src/data/backupCopy.json")
 
 const CRAWL_DELAY_MS = 100; // Polite delay
-const MAX_RETRIES = 3;       // Max attempts
-const RETRY_DELAY_MS = 2000; // Base backoff time
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * Retry-aware fetch:
- * - retries: Network errors, 5xx Server Errors, and 429 (Rate Limit) with linear backoff.
- * - aborts fast on fatal 4xx (except 429)
- * - returns parsed JSON on success
- */
-async function fetchWithRetry(url, maxRetries = MAX_RETRIES) {
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-        try {
-            logger.info(`Fetching ${url} (attempt ${attempt}/${maxRetries})`);
-            const response = await fetch(url);
-            const status = response.status;
-            if (response.ok) return await response.json();
-            if (status >= 400 && status < 500 && status !== 429) {
-                throw new Error(`Fatal Client Error ${status}: ${response.statusText} - Will not retry.`);
-            }
-            throw new Error(`Request failed with status ${status}: ${response.statusText}`);
-        } catch (error) {
-            if (error.message.includes("Fatal Client Error")) throw error;
-            logger.warn(`Attempt ${attempt} failed for ${url}: ${error.message}`);
-            if (attempt === maxRetries) throw new Error(`Failed after ${maxRetries} attempts: ${error.message}`);
-            const delay = RETRY_DELAY_MS * attempt;
-            logger.info(`Waiting ${delay}ms before next retry...`);
-            await sleep(delay);
-        }
-    }
-}
 
 /**
 * Main crawler loop:


### PR DESCRIPTION
- Reduced wait times for unresponsive APIs from 180s to 15s
- Refactored fetchWithRetry logic to crawler_functions
- crawlStacApi now uses fetchWithRetry